### PR TITLE
Rename promptText -> prompt.

### DIFF
--- a/addon/templates/components/form-fields/select-field.hbs
+++ b/addon/templates/components/form-fields/select-field.hbs
@@ -20,8 +20,8 @@
       groupLabelPath=groupLabelPath
       hidden=hidden
       includeBlank=includeBlank
-      promptText=promptText
-      promptIsSelectable=promptText
+      prompt=promptText
+      promptIsSelectable=promptIsSelectable
       lang=lang
       multiple=multiple
       options=options


### PR DESCRIPTION
The API for ember-one-way-controls has changed.

Unless we use `prompt` here, prompt becomes an alias
of includeBlank.

https://github.com/DockYard/ember-one-way-controls/blob/master/addon/components/one-way-select.js#L123